### PR TITLE
Make speed adjustable when limping

### DIFF
--- a/addons/movement/functions/fnc_getSpeed.sqf
+++ b/addons/movement/functions/fnc_getSpeed.sqf
@@ -21,6 +21,9 @@ private _trans = (((animationState cem_player) find "_") != -1 && (animationStat
 private _wepState = (((animationState cem_player) select [13,3]) == "low");
 private _inputs = (inputAction "WalkRunTemp" > 0 || inputAction "WalkRunToggle" > 0 || inputAction "turbo" > 0 || inputAction "TurboToggle" > 0 || stance cem_player == "PRONE");
 
+/* If limping return max of 2 */
+if ((toUpper ((animationState cem_player) select [8,4])) isEqualTo "MLMP") exitWith { (GVAR(speeds) select (GVAR(speed) min 2)) + [cem_movement_speed]; };
+
 if _trans exitWith { ["JOG", 1, 7] };
 if _wepState exitWith { ["JOG", 1, 7] };
 if _inputs exitWith { ["JOG", 1, 7] };

--- a/addons/movement/functions/fnc_speedPFH.sqf
+++ b/addons/movement/functions/fnc_speedPFH.sqf
@@ -20,7 +20,7 @@ if (GVAR(safeMapping)) then {
 };
 
 if ((speed cem_player) isEqualTo 0) exitWith {
-    if (!GVAR(AnimSpeedDisabled) || { (toUpper ((animationState cem_player) select [8,4])) isEqualTo "MLMP" }) then {
+    if (!GVAR(AnimSpeedDisabled)) then {
         [cem_player, 1] remoteExec ["setAnimSpeedCoef"]; 
         GVAR(AnimSpeedDisabled) = true;
     };
@@ -34,9 +34,9 @@ if (GVAR(oldSpeed) isNotEqualTo _speed) then {
         cem_player forceWalk false;
     };
 
+    [cem_player, (_speed select 1)] remoteExec ["setAnimSpeedCoef"];
+    GVAR(AnimSpeedDisabled) = false;
     GVAR(oldSpeed) = _speed;
 };
 
-/* Needs to be run on every frame due to strange arma bug */
-[cem_player, (_speed select 1)] remoteExec ["setAnimSpeedCoef"];
-GVAR(AnimSpeedDisabled) = false;
+/* Needs to be run on every frame due to some strange arma bug resetting the animSpeedCoef to 1 on every frame */

--- a/addons/movement/initKeybinds.sqf
+++ b/addons/movement/initKeybinds.sqf
@@ -10,6 +10,8 @@ private _category = format ["CE: %1", localize LSTRING(Category)];
         localize LSTRING(MovementSpeedUpTooltip)
     ], 
     {
+        /* If limping return max of 2 */
+        if ((toUpper ((animationState cem_player) select [8,4])) isEqualTo "MLMP") exitWith { GVAR(speed) = (GVAR(speed) + 1) min 2; };
         GVAR(speed) = (GVAR(speed) + 1) min 7;
     }, 
     { },


### PR DESCRIPTION
**When merged this pull request will:**
- Allows the speed to be adjusted when limping
- Speed is clamped to only slower than normal when limping
- Closes https://github.com/clustermod/CEM3/issues/14

### IMPORTANT
- [X] If the contribution affects [the documentation](https://wiki.cluster-community.com/index.php?title=Category:Cluster_Community_Mod_(CEM3)), please update any affected pages or add new ones, and mark the new documentation with the pull request link and ID.
- [X] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
