### PR TITLE
Fix Animation Speed Coefficiency being reset

### DIFF
--- a/addons/main/script_version.hpp
+++ b/addons/main/script_version.hpp
@@ -1,4 +1,4 @@
 #define MAJOR 0
 #define MINOR 1
 #define PATCHLVL 7
-#define BUILD 113
+#define BUILD 116

--- a/addons/movement/XEH_postInit.sqf
+++ b/addons/movement/XEH_postInit.sqf
@@ -1,5 +1,6 @@
 #include "script_component.hpp"
 
+GVAR(override) = false;
 GVAR(speeds) = [["WALK", 0.5], ["WALK", 0.7], ["WALK", 1], ["WALK", 1.2], ["WALK", 1.5], ["WALK", 1.8], ["JOG", 0.9], ["JOG", 1]];
 GVAR(oldStance_ui) = -1;
 GVAR(oldSpeed) = ["", -1];

--- a/addons/movement/functions/fnc_speedPFH.sqf
+++ b/addons/movement/functions/fnc_speedPFH.sqf
@@ -27,7 +27,12 @@ if (GVAR(oldSpeed) isNotEqualTo _speed) then {
         cem_player forceWalk false;
     };
 
-    [cem_player, (_speed select 1)] remoteExec ["setAnimSpeedCoef"];
     GVAR(AnimSpeedDisabled) = false;
     GVAR(oldSpeed) = _speed;
+};
+
+// Setting speedcoef every frame to make compatible with other mods
+// Allow overriding by other modders / scripters
+if (!GVAR(override)) then {
+    [cem_player, (_speed select 1)] remoteExec ["setAnimSpeedCoef"];
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Fix Animation Speed coefficiency being reset
- Add ability to override speed
- Close https://github.com/clustermod/CEM3/issues/20

### IMPORTANT
- [X] If the contribution affects [the documentation](https://wiki.cluster-community.com/index.php?title=Category:Cluster_Community_Mod_(CEM3)), please update any affected pages or add new ones, and mark the new documentation with the pull request link and ID.
- [X] Title of this PR uses our standard template `Component - Add|Fix|Improve|Change|Make|Remove {changes}`.
